### PR TITLE
Improvemapping

### DIFF
--- a/doc/sdms_iog_ch02-discovery-gcmd.adoc
+++ b/doc/sdms_iog_ch02-discovery-gcmd.adoc
@@ -127,11 +127,6 @@ Below is a mapping table between the internal metadata model described in <<disc
 |Entry_Title
 |
 
->|dataset_production_status
-|Data_Set_Progress
-|Dataset_Progress
-|
-
 >|abstract 
 |Summary/Abstract
 |Summary/Abstract
@@ -220,15 +215,15 @@ When provided, the DIF element Location is mapped into keywords of type https://
 Below a mapping between the internal model and  https://vocab.met.no/mmd/Related_Information_Types[Related information types] and DIF Related_URL (Type and Subtype)
 [%header, cols="1,2,2", header=True]
 |===
-|Internal model          |DIF 9 (Type/Subtype)                             |DIF 10.2 (Type/Subtype)
-|Project home page       |VIEW PROJECT HOME PAGE/ |PROJECT HOME PAGE/
-|Users guide             |VIEW RELATED INFORMATION/USER'S GUIDE|VIEW RELATED INFORMATION/USER'S GUIDE
-|Dataset landing page    |VIEW DATA SET LANDING PAGE/ |DATA SET LANDING PAGE/
-|Data server landing page|GET DATA/THREDDS DATA |USE SERVICE API/THREDDS DATA
-|Scientific publication  |VIEW RELATED INFORMATION/PUBLICATIONS |VIEW RELATED INFORMATION/PUBLICATIONS
-|Data paper              |VIEW RELATED INFORMATION/PUBLICATIONS |VIEW RELATED INFORMATION/PUBLICATIONS
+|Internal model          |DIF 9 (Type/Subtype)                           |DIF 10.2 (Type/Subtype)
+|Project home page       |VIEW PROJECT HOME PAGE/                        |PROJECT HOME PAGE/
+|Users guide             |VIEW RELATED INFORMATION/USER'S GUIDE          |VIEW RELATED INFORMATION/USER'S GUIDE
+|Dataset landing page    |VIEW DATA SET LANDING PAGE/                    |DATA SET LANDING PAGE/
+|Data server landing page|GET DATA/THREDDS DATA                          |USE SERVICE API/THREDDS DATA
+|Scientific publication  |VIEW RELATED INFORMATION/PUBLICATIONS          |VIEW RELATED INFORMATION/PUBLICATIONS
+|Data paper              |VIEW RELATED INFORMATION/PUBLICATIONS          |VIEW RELATED INFORMATION/PUBLICATIONS
 |Other documentation     |VIEW RELATED INFORMATION/GENERAL DOCUMENTATION |VIEW RELATED INFORMATION/GENERAL DOCUMENTATION
-|Extended metadata       |VIEW EXTENDED METADATA/ |EXTENDED METADATA/
+|Extended metadata       |VIEW EXTENDED METADATA/                        |EXTENDED METADATA/
 |===
 
 [#data_accessdif]
@@ -237,9 +232,11 @@ Below a mapping between the internal model and   https://vocab.met.no/mmd/Data_A
 
 [%header, cols="1,2,2", header=True]
 |===
-|Internal model |DIF 9 (Type/Subtype)                   |DIF 10.2 (Type/Subtype)
-|HTTP           |GET DATA/                              |GET DATA/DIRECT DOWNLOAD
-|OPeNDAP        |GET DATA/OPENDAP DATA (DODS)           |USE SERVICE API/OPENDAP DATA
-|OCG WMS        |GET SERVICE/GET WEB MAP SERVICE (WMS)  |USE SERVICE API/WEB MAP SERVICE (WMS)
-|FTP            |                                       |GET DATA/DIRECT DOWNLOAD
+|Internal model |DIF 9 (Type/Subtype)                      |DIF 10.2 (Type/Subtype)
+|HTTP           |GET DATA/                                 |GET DATA/DIRECT DOWNLOAD
+|OPeNDAP        |GET DATA/OPENDAP DATA (DODS)              |USE SERVICE API/OPENDAP DATA
+|OCG WMS        |GET SERVICE/GET WEB MAP SERVICE (WMS)     |USE SERVICE API/WEB MAP SERVICE (WMS)
+|OGC WFS        |GET SERVICE/GET WEB FEATURE SERVICE (WFS) |USE SERVICE API/WEB FEATURE SERVICE (WFS)
+|OGC WCS        |GET SERVICE/GET WEB COVERAGE SERVICE (WCS)|USE SERVICE API/WEB COVERAGE SERVICE (WCS)
+|FTP            |GET DATA/                                 |GET DATA/DIRECT DOWNLOAD
 |===

--- a/doc/sdms_iog_ch02-discovery-gcmd.adoc
+++ b/doc/sdms_iog_ch02-discovery-gcmd.adoc
@@ -1,6 +1,7 @@
 ===== GCMD DIF
 
 The Global Change Master Directory (GCMD) Directory Interchange Format (DIF) <<RD-16>> is a metadata standard that is widely used (e.g. by the Antarctic Metadata Directory) and that was the foundation for data management during the International Polar Year.
+SDMS is supporting both DIF 10.2 (the latest version of the standard), and also older versions (DIF 9) although deprecated.
 
 ////
 <<gcmd-dif-elements>> shows elements in GCMD DIF and whether these are **M**andatory, **R**ecommended or **O**ptional, as well as whether they are **U**nique (only one occurrence allowed) and require utilisation of **C**ontrolled vocabularies.
@@ -98,6 +99,147 @@ GCMD do not require a controlled vocabulary for the quality element.
 SDMS should to improve search resultsfootnote:[This work should relate to international activities in this field in the context of e.g. GEO, ICES, WMO etc. and must be coordinated within SDMS by the Terminology Team. ].
 Recommendation::
 Related_URL has several subtypes. The existing http://gcmdservices.gsfc.nasa.gov/static/kms/rucontenttype/rucontenttype.csv[list of type and subtype] must be used to allow the SIOS Data Portal to filter the purpose of the URLs provided. 
-When types are “View Data Set Landing Page”, “View Extended Metadata”, “View Professional Home Page”, and “View Project Home Page”, no subtype is needed.
+See <<related_informationdif>> and <<data_accessdif>> below for more information.
 Recommendation::
 All times must be encoded as ISO8601 either as YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ.
+
+
+Below is a mapping table between the internal metadata model described in <<discovery-model-elements>> and the DIF elements.
+[.landscape]
+<<<
+[[discovery-model-dif-mapping]]
+[cols="15,~,~,~",title="Mapping between the discovery model elements and DIF (version 9 and 10.2)"]
+|=======================================================================
+|Element |GCMD DIF 9 | GCMD DIF 10.2 | Comment/Note
+
+>|metadata_identifier 
+|Entry_ID
+|Entry_ID/ShortName 
+|The subfield ShortName for DIF 10.2
+
+>|last_metadata_update 
+|DIF_Creation_Date and Last_DIF_Revision_Date
+|Metadata_Dates/Metadata_Creation and Metadata_Dates/Metadata_Last_Revision
+|Use the subfields Metadata_Creation and Metadata_Last_Revision in DIF 10.2. Text entries such as "Not provided" are not parsed.
+
+>|title 
+|Entry_Title
+|Entry_Title
+|
+
+>|dataset_production_status
+|Data_Set_Progress
+|Dataset_Progress
+|
+
+>|abstract 
+|Summary/Abstract
+|Summary/Abstract
+|
+
+>|temporal_extent 
+|Temporal_Coverage
+|Temporal_Coverage/Range_DateTime
+|Use Start_Date and Stop_Date for DIF 9 and use Beginning_Date_Time and Ending_Date_Time for DIF 10.2
+
+>|geographic_extent 
+|Spatial_Coverage
+|Spatial_Coverage
+|For DIF 10.2 the subfields dif:Geometry/dif:Bounding_Rectangle, dif:Geometry/dif:Point and dif:Geometry/dif:Polygon are supported.
+
+>|iso_topic_category
+|ISO_Topic_Category
+|ISO_Topic_Category
+|
+
+>|keywords
+|Parameters and Keyword
+|Science_Keywords and Ancillary_Keyword
+|Parameters (DIF 9) and Science_Keywords (DIF 10.2) are translated into GCMD Science Keywords. Keyword (DIF 9) and Ancillary_Keyword (DIF 10.2) are translatde into generic keywords.
+
+>|personnel
+|Personnel and Data_Center/Personnel
+|Personnel and Organization/Personnel
+|Information about Data Center Contact is conveyed through the Personnel subfields of Data_Center (DIF 9) or Organization (DIF 10.2)
+
+>|data_access
+|Related_URL
+|Related_URL
+|Use the appropriate combination of URL_Content_Type/Type and URL_Content_Type/Subtype to identify the type of access and URL to provide the resource.
+Details are provided in the <<data_accessdif>> below.
+
+>|related_information
+|Related_URL
+|Related_URL
+|Use the appropriate combination of URL_Content_Type/Type and URL_Content_Type/Subtype to identify the type of access and URL to provide the resource.
+Details are provided in the <<related_informationdif>> below.
+
+>|use_constraint 
+|Use_Constraint
+|Use_Constraint
+|Use the subfields License_URL/Title and License_URL/URL in DIF 10.2 to provide license indentifier and URL.
+Information that cannot be mapped to standard licenses will be translated into license text.
+
+>|data_center 
+|Data_Center
+|Organization
+|Use the subfields Data_Center_Name/Short_Name, Data_Center_Name/Long_Name and Data_Center_URL in DIF 9.+
+Use the subfields Organization/Short_Name, Organization/Long_Name and Organization_URL in DIF 10.2 with Organization_Type "ARCHIVER"
+
+
+>|project 
+|Project
+|Project
+|Use the subfields Short_Name and Long_Name. 
+
+>|dataset_language 
+|Data_Set_Language
+|Dataset_Language
+|
+
+>|storage_information 
+|Distribution
+|Distribution
+|Use the subfield Distribution_Format.footnote:[This is not parsed for the time being.] 
+
+>|platform
+|Source_Name
+|Platform
+|Subfields Sensor_Name (DIF 9) and Instrument (DIF 10.2) are used to convey information about instruments.footnote:[This is not parsed for the time being.] 
+
+|=======================================================================
+
+[.portrait]
+<<<
+
+====== Location 
+When provided, the DIF element Location is mapped into keywords of type https://vocab.met.no/mmd/Keywords_Vocabulary/GCMDLOC[GCMDLOC].
+
+[#related_informationdif]
+====== Related information (URLs)
+Below a mapping between the internal model and  https://vocab.met.no/mmd/Related_Information_Types[Related information types] and DIF Related_URL (Type and Subtype)
+[%header, cols="1,2,2", header=True]
+|===
+|Internal model          |DIF 9 (Type/Subtype)                             |DIF 10.2 (Type/Subtype)
+|Project home page       |VIEW PROJECT HOME PAGE/ |PROJECT HOME PAGE/
+|Users guide             |VIEW RELATED INFORMATION/USER'S GUIDE|VIEW RELATED INFORMATION/USER'S GUIDE
+|Dataset landing page    |VIEW DATA SET LANDING PAGE/ |DATA SET LANDING PAGE/
+|Data server landing page|GET DATA/THREDDS DATA |USE SERVICE API/THREDDS DATA
+|Scientific publication  |VIEW RELATED INFORMATION/PUBLICATIONS |VIEW RELATED INFORMATION/PUBLICATIONS
+|Data paper              |VIEW RELATED INFORMATION/PUBLICATIONS |VIEW RELATED INFORMATION/PUBLICATIONS
+|Other documentation     |VIEW RELATED INFORMATION/GENERAL DOCUMENTATION |VIEW RELATED INFORMATION/GENERAL DOCUMENTATION
+|Extended metadata       |VIEW EXTENDED METADATA/ |EXTENDED METADATA/
+|===
+
+[#data_accessdif]
+====== Data access
+Below a mapping between the internal model and   https://vocab.met.no/mmd/Data_Access_Types[Data Access types] and DIF Related_URL (Type and Subtype)
+
+[%header, cols="1,2,2", header=True]
+|===
+|Internal model |DIF 9 (Type/Subtype)                   |DIF 10.2 (Type/Subtype)
+|HTTP           |GET DATA/                              |GET DATA/DIRECT DOWNLOAD
+|OPeNDAP        |GET DATA/OPENDAP DATA (DODS)           |USE SERVICE API/OPENDAP DATA
+|OCG WMS        |GET SERVICE/GET WEB MAP SERVICE (WMS)  |USE SERVICE API/WEB MAP SERVICE (WMS)
+|FTP            |                                       |GET DATA/DIRECT DOWNLOAD
+|===

--- a/doc/sdms_iog_ch02-discovery-iso19115.adoc
+++ b/doc/sdms_iog_ch02-discovery-iso19115.adoc
@@ -37,7 +37,7 @@ Below is a mapping table between the internal metadata model described in <<disc
 [.landscape]
 <<<
 [[discovery-model-iso-mapping]]
-[cols="10%,50%,40%",title="Mapping between the discovery model elements and ISO19115"]
+[cols="15,~,~",title="Mapping between the discovery model elements and ISO19115"]
 |=======================================================================
 |Internal metadata model element |ISO19115 |Comment/Note
 
@@ -56,10 +56,6 @@ Below is a mapping table between the internal metadata model described in <<disc
 >|abstract 
 |gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract 
 |
-
->|dataset_production_status 
-|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:status
-|Valid entries for gmd:MD_ProgressCode/@codeListValue will parsed. A default "Not available" will be used otherwise.
 
 >|temporal_extent 
 |gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod
@@ -131,10 +127,10 @@ gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_
 
 The following approach is currently used for keywords and vocabularies:
 
-* parsing of keyword type in gmd:type/gmd:MD_KeywordTypeCode/@codeListValue is performed looking for the values 'theme' or 'project' to fill the keywords or project elements in the internal metadata model 
+* parsing of keyword type in gmd:type/gmd:MD_KeywordTypeCode/@codeListValue is performed looking for the values 'theme' or 'project' to fill the keywords or project elements in the internal metadata model
 * parsing of thesauri in gmd:thesaurusName/gmd:CI_Citation/gmd:title is performed looking for GEMET or CF Standard names
 * parsing of gmd:keyword/gco:CharacterString or gmd:keyword/gmx:Anchor is performed for GEMET and CF Standard names
-* parsing of gmd:keyword/gco:CharacterString including "EARTH SCIENCE" is used to discriminate GCMD Science Keywords
+* parsing of gmd:keyword/gco:CharacterString starting with 'EARTH SCIENCE &gt;' is used to discriminate GCMD Science keywords. The full path of the GCMD science keywords including '&gt;' is required.
 
 
 [#use_constraintsiso]

--- a/doc/sdms_iog_ch02-discovery-iso19115.adoc
+++ b/doc/sdms_iog_ch02-discovery-iso19115.adoc
@@ -18,8 +18,6 @@ For stations where it is relevant (e.g. stations contributing to WMO GCW through
 Recommendation::
 Metadata records *should* include information on the host data centre for the dataset.
 
-NOTE: More details to be added on ISO19115 guidance. In particular on how to embed references to the vocabularies used and information on the data centre hosting the data.
-
 ////
 This table is removed for the time being, using the mapping table instead
 <<iso19115-core-elements>> shows elements in ISO19115 and whether these are **M**andatory,
@@ -28,13 +26,165 @@ This table is removed for the time being, using the mapping table instead
 vocabularies.
 ////
 
-NOTE: SDMS interprets both gmd:MD_Metadata and gmi:MI_Metadata. 
+NOTE: SDMS interprets both gmd:MD_Metadata (ISO 19115-1) and gmi:MI_Metadata (ISO 19115-2). The mdb:MD_Metadata (ISO 19115-3) is not supported.
 
-NOTE: How to add dataset landing pages etc are still a bit fuzzy. SDMS still interprets dataSetURI as a dataset landing page, but this is deprecated in ISO. Some data centres put dataset landing pages in gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource and use a combination of various elements like gmd:function/gmd:CI_OnLineFunctionCode, gmd:name/gco:CharacterString to identify relevant additional information. SDMS is currently interpreting phrases like "Extended human readable information about the dataset" and "Landing page" as Dataset landing pages when found. Information tagged "Project on RiS" is translated into the category Other documentation and "Homepage" is interpreted as a project home page reference. More details need to be agreed on this.
-
+//// 
+This is now in the table below.
 NOTE: SDMS will extract name of the project that has generated the data from the descriptiveKeywords if these have gmd:type/gmd:MD_KeywordTypeCode set to 'project'. More details need to be agreed on this.
+////
+
+Below is a mapping table between the internal metadata model described in <<discovery-model-elements>> and the ISO19115 elements.
+[.landscape]
+<<<
+[[discovery-model-iso-mapping]]
+[cols="10%,50%,40%",title="Mapping between the discovery model elements and ISO19115"]
+|=======================================================================
+|Internal metadata model element |ISO19115 |Comment/Note
+
+>|metadata_identifier 
+|gmd:fileIdentifier/gco:CharacterString  
+|
+
+>|last_metadata_update 
+|gmd:dateStamp 
+|ISO supports both gco:Date or gco:DateTime. A default time is added when a gco:Date type is provided.
+
+>|title 
+|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString 
+|
+
+>|abstract 
+|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract 
+|
+
+>|dataset_production_status 
+|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:status
+|Valid entries for gmd:MD_ProgressCode/@codeListValue will parsed. A default "Not available" will be used otherwise.
+
+>|temporal_extent 
+|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod
+|Relies on gml:beginPosition always to be present and in the date/datetime domain: The use of indeterminatePosition is not supported. 
+If gml:endPosition is missing or of type indeterminatePosition it will not be parsed and considered an ongoing observational effort.  
+A default time is added when a date only entry is provided. 
+
+>|geographic_extent 
+|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox 
+|
+
+>|iso_topic_category
+|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode 
+|If this element is not provided a default "Not available" will be used.
+
+>|keywords
+|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString
+|The scope for keywords has to be identified by identification of the purpose (parameter/variable definitions, projects etc) of keywords in ISO records.
+Details on how this is done is provided in the <<keywordsiso>> section below.
+
+>|personnel 
+a|* gmd:contact/gmd:CI_ResponsibleParty 
+* gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty
+|Extraction and crediting people involved relies on gmd:role/gmd:CI_RoleCode to have attribute codeListValue set according to a predefined set of values. ISO codes principalInvestigator, pointOfContact, and author are translated into roles of Principal Investigator, Technical Contact, Metadata Author respectively. Roles not listed above are translated into Technical Contact. 
+
+>|data_access
+|gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource
+|This implies that elements gmd:protocol/gco:CharacterString and gmd:linkage/gmd:URL must be set.
+See <<data_accessiso>> section below.
+
+>|related_information
+a|* gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource +
+ * gmd:dataSetURI/gco:CharacterString
+|A combination of gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue and gmd:name/gco:CharacterString is used to parse this information. See <<related_informationiso>> section below.
+
+>|use_constraint 
+|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation or +
+gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_Constraints/gmd:useLimitation or +
+gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useConstraints
+|See <<use_constraintsiso>> section below more information.
+
+>|data_center 
+|gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor with gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode/@codeListValue = 'distributor' or 'publisher'.
+|The long name goes into gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString and the URL for the data center into gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL.
+
+>|project 
+|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString with /gmd:type/gmd:MD_KeywordTypeCode[@codeListValue = 'project']
+|Project information is conveyed through keywords in ISO19115 profiles.
+
+
+>|dataset_language 
+|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:language 
+|
+
+>|storage_information 
+|/gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat/gmd:MD_Format
+|use gmd:name/gco:CharacterString to provide the format of the dataset
+
+>|platform 
+|/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:type/gmd:MD_KeywordTypeCode with codeListValue="platform"
+|Not parsed.footnote:[This field is currently not parsed and mapping information might be modified in the future.]
+
+|=======================================================================
+
+[.portrait]
+<<<
+[#keywordsiso]
+====== Keywords and vocabulary
+
+The following approach is currently used for keywords and vocabularies:
+
+* parsing of keyword type in gmd:type/gmd:MD_KeywordTypeCode/@codeListValue is performed looking for the values 'theme' or 'project' to fill the keywords or project elements in the internal metadata model 
+* parsing of thesauri in gmd:thesaurusName/gmd:CI_Citation/gmd:title is performed looking for GEMET or CF Standard names
+* parsing of gmd:keyword/gco:CharacterString or gmd:keyword/gmx:Anchor is performed for GEMET and CF Standard names
+* parsing of gmd:keyword/gco:CharacterString including "EARTH SCIENCE" is used to discriminate GCMD Science Keywords
+
+
+[#use_constraintsiso]
+====== Use constraints
+
+The recommended way to provide a license is:
+[source,xml]
+----
+<gmx:Anchor xlink:href="http://spdx.org/licenses/CC-BY-4.0">CC-BY-4.0</gmx:Anchor>
+----
+
+Where the identifier (adhering to the SPDX formatting) goes into gmx:Anchor and the link to the text into the attribute of this xlink:href. This is currently a recommended field, but it is strongly recommended and  suggested to become mandatory in the future.
+Licenses that cannot be mapped to standard licenses will be parsed as text. Some mapping stragegy is also in place during harvesting license.footnote:[An internal mapping is done upon harvesting to parse license title or exact maching urls. If provided, a gco:CharacterString can also parsed.]
+
+[#related_informationiso]
+====== Related information (URLs)
+
+Links to related information can be quite difficult to parse due to the degrees of freedom in ISO.
+The internal model is supporting related information of different types based on the https://vocab.met.no/mmd/Related_Information_Types[Related Information Types] controlled list.
+Currently:
+
+* SDMS still interprets gmd:dataSetURI as a "Dataset landing page", but this is deprecated in ISO.
+* gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource
+and a combination of gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue='information' and
+gmd:name/gco:CharacterString can also be used to identify a dataset landing page.
+SDMS is currently interpreting phrases like "Extended human readable information about the dataset" and "Landing page" as URL of type "Dataset landing page" when found.
+* Information tagged "Project on RiS" is translated into the category "Other documentation"
+* "Homepage" is interpreted as a "Project home page" reference.
+
+[#data_accessiso]
+====== Data access
+
+The gmd:protocol containing a predefined keywordfootnote:[OSGEO or GeoNetwork keywords are required for proper interpretation. These keywords are translated in the harvesting routine.] and the gmd:linkage/gmd:URL are used to parse the different data access links.
+This is used both to identify direct download of datasets (i.e. HTTP or FTP) as well as services on top of dataset (e.g. OPeNDAP, OGC WMS).
+It is important to note that direct download should not refer to a website requiring manual intervention. Direct download will be handled by the basket in the data portal and enables bundling of data for download etc.
+
+Below the list of currently mapped protocols:
+[%header, cols="2,3,1", header=True]
+|===
+| ISO Inspire gmd:protocol (OSGEO) | ISO Inspire gmd:protocol (GeoNetwork)|Internal model
+|download                          |WWW:DOWNLOAD-1.0-http--download       |HTTP
+|OPeNDAP:OPeNDAP                   |WWW:LINK-1.0-http--opendap            |OPeNDAP
+|OGC:WMS                           |OGC:WMS                               |OCG WMS
+|OGC:WFS                           |OGC:WFS                               |OCG WFS
+|OGC:WCS                           |OGC:WCS                               |OCG WCS
+|ftp                               |WWW:DOWNLOAD-1.0-ftp--download        |FTP
+|===
 
 ////
+
 WARNING: The table below is under review.
 
 [[iso19115-core-elements]]

--- a/doc/sdms_iog_ch02-discovery-model-mapping.adoc
+++ b/doc/sdms_iog_ch02-discovery-model-mapping.adoc
@@ -4,103 +4,57 @@ GCMD Data_Set_Citation is missing, need to add.
 [.landscape]
 <<<
 [[discovery-model-elements]]
-[cols="15,~,~,~",title="Discovery model elements and mappings against exchange standards."]
+[cols="2,5",title="Discovery model elements"]
 |=======================================================================
-|Element |Description |ISO19115 |GCMD DIF 
+|Element |Description 
 
 >|metadata_identifier 
 | A unique identifier (A UUID with namespace is recommended) for the dataset. 
-|gmd:fileIdentifier/gco:CharacterString  
-|Entry_ID 
 
-|last_metadata_update 
+>|last_metadata_update 
 | Last date of updated metadata using the form YYYY-MM-DDTHH:MM:SSZ 
-|gmd:dateStamp 
-|FIXME
 
 >|title 
 |A short title for the dataset. 
-|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString 
-|Entry_Title
 
 >|abstract 
 |Short summary describing the dataset embedded in gco:CharacterString.  
-|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract 
-|Summary
 
 >|temporal_extent 
 |Temporal extent of the dataset. Currently gaps are not handled.  
-|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod +
-Relies on gml:beginPosition always to be present, if gml:endPosition is missing it is considered an ongoing observational effort.
-|Temporal_Coverage
 
 >|geographic_extent 
 |Spatial extent of the dataset.  Requires all 4 corners (gmd:northBoundLatitude/gco:Decimal etc) of the BoundingBox to be set, also for point measurements. Points are interpreted if values are identical. 
-|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox 
-|Spatial_Coverage
 
 >|iso_topic_category
 |ISO Topic Category, using a controlled vocabulary. 
-|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode 
-|ISO_Topic_Category
 
 >|keywords
 |A word or phrase that describes some aspect of a resource. Can be one of several types. It is used to describe the parameters in a dataset, the project affiliation etc. Proper identification of the purpose of the keywords and the vocabularies used is required. Project names are used to tag datasets in the SDMS system, e.g. as SIOS Core Data, SESS 2020 etc. If the keyword starts with 'EARTH SCIENCE &gt;' keywords are extracted and put in a separate list for GCMD keywords and used in the search interface. The full path of GCMD science keywords including '&gt;' is required. 
-|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString  +
-The scope for keywords has to be identified by identification of the purpose (parameter/variable definitions, projects etc) of keywords in ISO records.
-Details on how this is done is provided below.
-|Parameters +
-Earth Science keywords.
 
 >|personnel 
 |This field is used to identify personnel with various roles in relation to the dataset. It should also include contact information, at least email address and name of the affiliated institution, role (see below) and name. 
-a|* gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty
-* gmd:contact/gmd:CI_ResponsibleParty
-* Extraction and crediting people involved relies on gmd:role/gmd:CI_RoleCode to have attribute codeListValue set according to a predefined set of values. ISO codes principalInvestigator, pointOfContact, and author are translated into roles of Principal Investigator, Technical Contact, Metadata Author respectively. Roles not listed above are translated into Technical Contact. 
-|Personnel +
-Extracts information from Originating_Center as well
 
 >|data_access
 |URL to the actual dataset accompanied with identification of the protocol supported.  
-|gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource +
-This implies that elements gmd:protocol/gco:CharacterString and gmd:linkage/gmd:URL must be set and the gmd:protocol contains a predefined keywordfootnote:[OSGEO or GCMD keywords are required for proper interpretation. More details to be added for this. These keywords are translated in the harvesting routine.]. This is used both to identify direct download of datasets (i.e. HTTP or FTP) as well as services on top of dataset (e.g. OPeNDAP, OGC WMS). It is important to note that direct download should not refer to a website requiring manual intervention. Direct download will be handled by the basket in the data portal and enables bundling of data for download etc.
-|Related_URL +
-The purpose of the URL has to be properly identified using the relevant fields and vocabularies. Details are provided below.
 
 >|use_constraint 
 |License for the metadata using https://spdx.org/licenses/[SPDX License List]. The identifier (adhering to the SPDX formatting) goes into gmx:Anchor and the link to the text into  the attribute of this xlink:href. This is currently a recommended field, but it is strongly recommended and suggested to become mandatory in the future. 
-|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation 
-|Use_Constraint
 
 >|data_center 
-|The host data center of the dataset. This should have both a long and short name, but only specification for the long name is currently identified. 
-|gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor +
-The long name goes into gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString and the URL for the data center into gmd:distributorContact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL. More information to be added. 
-|Data_Center
+|The host data center of the dataset. This should have both a long and short name, but only specification for the long name is currently identified for ISO mapping.
 
 >|project 
 |Project where the dataset was generated or collected. Preferably both short and long names should be provided.
-|FIXME +
-Project information is conveyed through keywords in ISO19115 profiles.
-The scope for keywords has to be identified by identification of the purpose (parameter/variable definitions, projects etc) of keywords in ISO records.
-Details on how this is done is provided below.
-|Project
 
 >|dataset_language 
-|Should be English. 
-|gmd:identificationInfo/gmd:MD_DataIdentification/gmd:language 
-|Data_Set_Language
+|The language used in production, storage etc. of the dataset. The default for all datasets is English.
 
 >|storage_information 
 |Should be NetCDF/CF or Darwin Core Archive in SDMS. Other standardised formats may be supported later. Non standard formats should have a detailed product manual. 
-|FIXME 
-|Distribution +
-Extracts information from the Distribution element FIXME
 
 >|platform
-|FIXME
-|FIXME
-|FIXME
+|The platform used to collect the data.footnote:[This is a complex field, with several subfields. It currently support a limited vocabulary.] 
 
 |=======================================================================
 

--- a/doc/sdms_iog_ch02-discovery-model-mapping.adoc
+++ b/doc/sdms_iog_ch02-discovery-model-mapping.adoc
@@ -1,8 +1,6 @@
 ////
 GCMD Data_Set_Citation is missing, need to add.
 ////
-[.landscape]
-<<<
 [[discovery-model-elements]]
 [cols="2,5",title="Discovery model elements"]
 |=======================================================================
@@ -24,19 +22,22 @@ GCMD Data_Set_Citation is missing, need to add.
 |Temporal extent of the dataset. Currently gaps are not handled.  
 
 >|geographic_extent 
-|Spatial extent of the dataset.  Requires all 4 corners (gmd:northBoundLatitude/gco:Decimal etc) of the BoundingBox to be set, also for point measurements. Points are interpreted if values are identical. 
+|Spatial extent of the dataset.  Requires all 4 corners of the BoundingBox to be set, also for point measurements. Points are interpreted if values are identical.
 
 >|iso_topic_category
 |ISO Topic Category, using a controlled vocabulary. 
 
 >|keywords
-|A word or phrase that describes some aspect of a resource. Can be one of several types. It is used to describe the parameters in a dataset, the project affiliation etc. Proper identification of the purpose of the keywords and the vocabularies used is required. Project names are used to tag datasets in the SDMS system, e.g. as SIOS Core Data, SESS 2020 etc. If the keyword starts with 'EARTH SCIENCE &gt;' keywords are extracted and put in a separate list for GCMD keywords and used in the search interface. The full path of GCMD science keywords including '&gt;' is required. 
+|A word or phrase that describes some aspect of a resource. It can be one of several types. It is used to describe the parameters in a dataset, the project affiliation etc. Proper identification of the purpose of the keywords and the vocabularies used is required. Project names are used to tag datasets in the SDMS system, e.g. as SIOS Core Data, SESS 2020 etc.
 
 >|personnel 
 |This field is used to identify personnel with various roles in relation to the dataset. It should also include contact information, at least email address and name of the affiliated institution, role (see below) and name. 
 
 >|data_access
 |URL to the actual dataset accompanied with identification of the protocol supported.  
+
+>|related_information
+|URL to relevant information regarding the dataset, accompanied with identification of the protocol supported. This could be, for example, a landing page, project page or scientific publication.
 
 >|use_constraint 
 |License for the metadata using https://spdx.org/licenses/[SPDX License List]. The identifier (adhering to the SPDX formatting) goes into gmx:Anchor and the link to the text into  the attribute of this xlink:href. This is currently a recommended field, but it is strongly recommended and suggested to become mandatory in the future. 
@@ -58,5 +59,3 @@ GCMD Data_Set_Citation is missing, need to add.
 
 |=======================================================================
 
-[.portrait]
-<<<

--- a/doc/sdms_iog_ch02-discovery.adoc
+++ b/doc/sdms_iog_ch02-discovery.adoc
@@ -138,7 +138,8 @@ NOTE: More information on schema.org to be added.
 ===== Internal discovery model
 
 SIOS is harvesting discovery metadata from data centres using established discovery metadata schemes and transforms this information into the internal information model used. 
-<<discovery-model-elements>> below shows the elements of the information model and mappings against ISO19115 and GCMD DIF.
+The <<discovery-model-elements>> below shows the elements of the information model while the mapping between the information model and the metadata 
+standard ISO 19115 and GCMD DIF are presented in the following sections.
 Further mappings are under development.
 
 include::sdms_iog_ch02-discovery-model-mapping.adoc[]


### PR DESCRIPTION
The PR: 
- Splits Table 1 to address separately the internal model, the mapping to ISO and to DIF 9/10.2 (#12 )
- A more clear mapping of protocols, type/subtype is provided (it's quite difficult to browse older version of the GCMD vocabulary, so I hope old mapping is ok, but not 100% sure). 
- Adds some text to iso to address #14 , stating only 19115-1 and 19115-2 are supported. 
- Adds some clarification to the handling of data center contact for ISO only for types distributor or publisher (#22)
- related_information is added to model and mapping.

I could not create a pdf with doctype article, so the transformation of the adoc is not uploaded.